### PR TITLE
Compare Summary Table updates

### DIFF
--- a/client/src/containers/CompareContainer.js
+++ b/client/src/containers/CompareContainer.js
@@ -37,8 +37,6 @@ function CompareContainer(props) {
       const allCatValues = [];
       for (const team of selectedTeams) {
         const dataRow = {};
-        dataRow['rowHeader'] = display;
-        dataRow['catId'] = catName;
 
         filteredData.forEach((row) => {
           if (row.teamId.toString() === team) {
@@ -61,6 +59,9 @@ function CompareContainer(props) {
         dataRow.stdev = stdev;
         dataRow.min = min;
         dataRow.max = max;
+        // Move to end so the '3' in 3PM isn't included in stats
+        dataRow['rowHeader'] = display;
+        dataRow['catId'] = catName;
 
         data.push(dataRow);
       }

--- a/client/src/containers/CompareContainer.js
+++ b/client/src/containers/CompareContainer.js
@@ -37,6 +37,8 @@ function CompareContainer(props) {
       const allCatValues = [];
       for (const team of selectedTeams) {
         const dataRow = {};
+        dataRow['rowHeader'] = display;
+        dataRow['catId'] = catName;
 
         filteredData.forEach((row) => {
           if (row.teamId.toString() === team) {
@@ -49,7 +51,7 @@ function CompareContainer(props) {
             allCatValues.push(dataPoint);
           }
         });
-        const dataRowValues = Object.values(dataRow);
+        const dataRowValues = Object.values(dataRow).splice(1);
         const mean = arrayMath.mean(dataRowValues).toFixed(digits);
         const stdev = arrayMath.stdev(dataRowValues).toFixed(digits);
         const min = Math.min(...arrayMath.filterNaN(dataRowValues));
@@ -59,9 +61,6 @@ function CompareContainer(props) {
         dataRow.stdev = stdev;
         dataRow.min = min;
         dataRow.max = max;
-        // Move to end so the '3' in 3PM isn't included in stats
-        dataRow['rowHeader'] = display;
-        dataRow['catId'] = catName;
 
         data.push(dataRow);
       }

--- a/client/src/tables/CompareSummaryTable.js
+++ b/client/src/tables/CompareSummaryTable.js
@@ -24,16 +24,16 @@ function CompareSummaryTable(props) {
             accessor: 'mean',
           },
           {
-            Header: 'StDev',
-            accessor: 'stdev'
-          },
-          {
             Header: 'Min',
             accessor: 'min',
           },
           {
             Header: 'Max',
             accessor: 'max',
+          },
+          {
+            Header: 'StDev',
+            accessor: 'stdev'
           },
         ],
       },

--- a/client/src/tables/CompareSummaryTable.js
+++ b/client/src/tables/CompareSummaryTable.js
@@ -134,13 +134,18 @@ function CompareSummaryTable(props) {
                         } else {
                           isLargest = cell.value > Math.max(...compare);
                         }
+                        
+                        let noColor;
+                        if (headerId === "stdev") {
+                          noColor = true;
+                        }
 
                         // Apply the cell props
                         return (
                           <td
                             {...cell.getCellProps()}
                             style={{
-                              background: isLargest ? 'limegreen' : 'gainsboro',
+                              background: (!noColor & isLargest) ? 'limegreen' : 'gainsboro',
                               fontWeight: isRowHeader ? 'bold' : 'normal',
                             }}
                             rowSpan={


### PR DESCRIPTION
A couple changes:
- Removes color from stdev columns and moves it to the end (happy to revert this if you prefer it as it was)
- Fixes bug where 3PM Min was always 3 because (I think) Math.min was including the '3' in 3PM.  Now the dataRow is spliced to exclude the row headers and avoid this