### PR TITLE
Coloring changes in  Roster Table

### DIFF
--- a/client/src/containers/RosterContainer.js
+++ b/client/src/containers/RosterContainer.js
@@ -136,6 +136,7 @@ function RosterContainer(props) {
               }
               cats={catsList}
               catColorRange={catColorRange}
+              statType={statType}
             />
           );
         })}

--- a/client/src/tables/RosterTable.js
+++ b/client/src/tables/RosterTable.js
@@ -45,13 +45,8 @@ function RosterTable(props) {
         Cell: (props) => {
           const val = props.value;
           const range = catColorRange[props.column.id];
-
-          // If displaying stats, use inverse coloring (for TO, etc.)
-          // If displaying ratings, use usual color gradient
-          let inverse;
-          if (statType === 'stats') inverse = getCatInverse(props.column.id);
-          else inverse = false
-
+          // If displaying stats, use inverse coloring where necessary (for TO, etc.)
+          const inverse = getCatInverse(props.column.id) && (statType === 'stats');
           const color = getHSLColor(val, range[0], range[1], inverse);
           return (
             <p style={{ background: color, minWidth: '30px' }}>

--- a/client/src/tables/RosterTable.js
+++ b/client/src/tables/RosterTable.js
@@ -46,7 +46,7 @@ function RosterTable(props) {
           const val = props.value;
           const range = catColorRange[props.column.id];
           // If displaying stats, use inverse coloring where necessary (for TO, etc.)
-          const inverse = getCatInverse(props.column.id) && (statType === 'stats');
+          const inverse = statType === 'stats' ? getCatInverse(props.column.id) : false;
           const color = getHSLColor(val, range[0], range[1], inverse);
           return (
             <p style={{ background: color, minWidth: '30px' }}>

--- a/client/src/tables/RosterTable.js
+++ b/client/src/tables/RosterTable.js
@@ -3,11 +3,13 @@ import { useTable, useSortBy } from 'react-table';
 import styled from 'styled-components';
 
 import { getHSLColor } from '../utils/colorsUtil';
+import { getCatInverse } from '../utils/categoryUtils';
 
 function RosterTable(props) {
   const data = props.data;
   const cats = props.cats;
   const catColorRange = props.catColorRange;
+  const statType = props.statType;
 
   data.sort((a, b) => {
     const aa = a.all || a.pts;
@@ -43,7 +45,14 @@ function RosterTable(props) {
         Cell: (props) => {
           const val = props.value;
           const range = catColorRange[props.column.id];
-          const color = getHSLColor(val, range[0], range[1]);
+
+          // If displaying stats, use inverse coloring (for TO, etc.)
+          // If displaying ratings, use usual color gradient
+          let inverse;
+          if (statType === 'stats') inverse = getCatInverse(props.column.id);
+          else inverse = false
+
+          const color = getHSLColor(val, range[0], range[1], inverse);
           return (
             <p style={{ background: color, minWidth: '30px' }}>
               {typeof val == 'number' ? parseFloat(val).toFixed(2) : ''}


### PR DESCRIPTION
If displaying stats, uses inverse coloring where applicable.  Otherwise (for ratings), defaults to normal coloring scheme 